### PR TITLE
Template class

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,6 +1,13 @@
+# Find header files for the Eigen matrix library
+# Usually in a standard location like /usr/include/eigen3/
+# Change manually here if needed
+EIGEN_INCLUDE := $(shell pkg-config --cflags eigen3)
+
+CXX_EIGEN_FLAGS := -Wno-ignored-attributes -Wno-misleading-indentation -Wno-deprecated-declarations
 CXX_OPT_FLAGS := -O3 -DNDEBUG
+CXX_FLAGS := $(CXX_OPT_FLAGS) $(CXX_EIGEN_FLAGS)
 
 simple_demo: simple_demo.cpp
-	g++ -I$(EIGENPATH) -I../src/ simple_demo.cpp -o simple_demo $(CXX_OPT_FLAGS)
+	g++ $(CXX_FLAGS) $(EIGEN_INCLUDE) -I../src/ simple_demo.cpp -o simple_demo
 
 all: simple_demo

--- a/examples/simple_demo.cpp
+++ b/examples/simple_demo.cpp
@@ -1,11 +1,11 @@
 #include <iostream>
 #include "Eigen/Dense"
-#include "KMeansRexCore.cpp"
+#include "KMeansRexCoreInterface.h"
+#include "KMeansRexCore.h"
 
-using namespace Eigen;
-using namespace std;
+using std::cout;
 
-IOFormat CleanFmt(3, 0, " ", "\n", "[", "]");
+Eigen::IOFormat CleanFmt(3, 0, " ", "\n", "[", "]");
 
 int main() {
     int K = 3;
@@ -38,7 +38,7 @@ int main() {
     Eigen::ArrayXXd mu = Eigen::ArrayXXd::Zero(K, n_features);
     Eigen::ArrayXd z = Eigen::ArrayXd::Zero(n_examples_ttl);
 
-    cout << "running kmeans ... \n";
+    cout << "running kmeans with the c interface (double) ... \n";
     RunKMeans(
         data_all.data(),
         n_examples_ttl, n_features, K,
@@ -49,5 +49,24 @@ int main() {
 
     cout << "estimated clusters:\n";
     cout << mu.format(CleanFmt) << "\n";
+
+    Eigen::ArrayXXf data_allf = data_all.cast<float>();
+    Eigen::ArrayXXf muf = Eigen::ArrayXXf::Zero(K, n_features);
+    Eigen::ArrayXf zf = Eigen::ArrayXf::Zero(n_examples_ttl);
+
+    cout << "running kmeans with template parameter 'float' ... \n";
+
+    KMeansRex::KMeansRex<float>(
+        data_allf.data(),
+        n_examples_ttl, n_features, K,
+        n_iters, seed, "plusplus",
+        muf.data(),
+        zf.data()
+    );
+
+    cout << "done.\n";
+
+    cout << "estimated clusters:\n";
+    cout << muf.format(CleanFmt) << "\n";
 
 }

--- a/matlab/KMeansRex.cpp
+++ b/matlab/KMeansRex.cpp
@@ -14,74 +14,66 @@ Date:   2 April 2013
 #include <iostream>
 #include <time.h>
 #include "mex.h"
-#include "Eigen/Dense"
 #include "KMeansRexCore.h"
-
-using namespace Eigen;
-using namespace std;
-
 
 /*  DEFINE Custom Type Names to make code more readable
     ExtMat :  2-dim matrix/array externally defined (e.g. in Matlab or Python)
 */
-typedef Map<ArrayXXd> ExtMat;
+typedef Eigen::Map<Eigen::ArrayXXd> ExtMat;
 
-void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) 
-{
-	if (nrhs < 2 || nrhs > 5 ) {
-		mexErrMsgTxt("Needs >=2 args -- Xdata (NxD), K (int), [OPTIONAL] Niter (int), initname (str), seed (int)");
-		return;
-	}
+void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
+    if (nrhs < 2 || nrhs > 5) {
+        mexErrMsgTxt("Needs >=2 args -- Xdata (NxD), K (int), [OPTIONAL] Niter (int), initname (str), seed (int)");
+        return;
+    }
 
-  // ============================================== Process optional inputs
-	int Niter;
-  if (nrhs >= 4) {
-    Niter   = (int) mxGetScalar( prhs[2] );
-  } else {
-    Niter   = 25;
-  }
+    // ============================================== Process optional inputs
+    int Niter;
+    if (nrhs >= 4) {
+        Niter = (int) mxGetScalar(prhs[2]);
+    } else {
+        Niter = 25;
+    }
 
-  char* initname;
-  if (nrhs >= 4) {
-    initname = mxArrayToString( prhs[3] );
-  } else {
-    initname = (char *) "plusplus";
-  }
+    char *initname;
+    if (nrhs >= 4) {
+        initname = mxArrayToString(prhs[3]);
+    } else {
+        initname = (char *) "plusplus";
+    }
 
-	if (nrhs == 5) {
-	  int SEED = (int) mxGetScalar( prhs[4] );
-  	set_seed( SEED );
-  } else {
-    set_seed( (int) clock() );
-	}
-	
-  // ============================================== Process required input K
-	int K = (int) mxGetScalar(prhs[1]);
+    int SEED = 42;
+    if (nrhs == 5) {
+        SEED = (int) mxGetScalar(prhs[4]);
+    } else {
+        SEED = (int) clock();
+    }
 
-	double* X_IN = mxGetPr(prhs[0]);	
-	int N = mxGetM( prhs[0] );
-	int D = mxGetN( prhs[0] );
-	ExtMat X (X_IN, N, D);
+    // ============================================== Process required input K
+    int K = (int) mxGetScalar(prhs[1]);
 
-  // =============================================  Input Sanity Checks
-	if (K <= 1 ) {
-	  mexErrMsgTxt("Need at least two clusters to avoid degeneracy.");
-	  return;
-	}
-	if (K >= N) {
-	  mexErrMsgTxt("Cannot request more clusters than data points.");
-		return;
-	}
-	
-  // =============================================  Allocate output Mu, Z
-	plhs[0] = mxCreateDoubleMatrix(K, D, mxREAL);
-  ExtMat Mu ( mxGetPr(plhs[0]), K, D );
-  
-	plhs[1] = mxCreateDoubleMatrix(N, 1, mxREAL);
-  ExtMat Z  ( mxGetPr(plhs[1]), N, 1 );
-  
-  // =============================================  Do the Work!
-  // Initialize and Run Lloyd Alg to convergence!  
-  init_Mu( X, Mu, initname);
-  run_lloyd( X, Mu, Z, Niter);
+    double *X_IN = mxGetPr(prhs[0]);
+    int N = mxGetM(prhs[0]);
+    int D = mxGetN(prhs[0]);
+    ExtMat X(X_IN, N, D);
+
+    // =============================================  Input Sanity Checks
+    if (K <= 1) {
+        mexErrMsgTxt("Need at least two clusters to avoid degeneracy.");
+        return;
+    }
+    if (K >= N) {
+        mexErrMsgTxt("Cannot request more clusters than data points.");
+        return;
+    }
+
+    // =============================================  Allocate output Mu, Z
+    plhs[0] = mxCreateDoubleMatrix(K, D, mxREAL);
+    ExtMat Mu(mxGetPr(plhs[0]), K, D);
+
+    plhs[1] = mxCreateDoubleMatrix(N, 1, mxREAL);
+    ExtMat Z(mxGetPr(plhs[1]), N, 1);
+
+    // =============================================  Do the Work!
+    KMeansRex::KMeansRex<double>(X.data(), N, D, K, Niter, SEED, initname, Mu.data(), Z.data());
 }

--- a/src/KMeansRexCore.cpp
+++ b/src/KMeansRexCore.cpp
@@ -34,169 +34,207 @@ Date:   2 April 2013
 
 #include <iostream>
 #include "KMeansRexCoreInterface.h"
+#include "KMeansRexCore.h"
 #include "mersenneTwister2002.c"
-#include "Eigen/Dense"
 
-using namespace Eigen;
-using namespace std;
+namespace KMeansRex {
 
-/*  DEFINE Custom Type Names to make code more readable
-    ExtMat :  2-dim matrix/array externally defined (e.g. in Matlab or Python)
-*/
-typedef Map<ArrayXXd> ExtMat;
-typedef ArrayXXd Mat;
-typedef ArrayXd Vec;
+    using namespace Eigen;
+    using namespace std;
 
-// ====================================================== Utility Functions
-void set_seed( int seed ) {
-  init_genrand( seed );
-}
+    template<typename T>
+    KMeansRex<T>::KMeansRex() {};
 
-int discrete_rand( Vec &p ) {
-    double total = p.sum();
-    int K = (int) p.size();
-    
-    double r = total*genrand_double();
-    double cursum = p(0);
-    int newk = 0;
-    while ( r >= cursum && newk < K-1) {
-        newk++;
-        cursum += p[newk];
+    template<typename T>
+    KMeansRex<T>::KMeansRex(T *X_IN, int N, int D, int K, int Niter,
+                            int seed, char *initname, T *Mu_OUT, T *Z_OUT) {
+        set_seed(seed);
+
+        ExtMat X(X_IN, N, D);
+        ExtMat Mu(Mu_OUT, K, D);
+        ExtMat Z(Z_OUT, N, 1);
+
+        init_Mu(X, Mu, initname);
+        run_lloyd(X, Mu, Z, Niter);
     }
-    if ( newk < 0 || newk >= K ) {
-        cerr << "Badness. Chose illegal discrete value." << endl;
-        return -1;
+
+    template<typename T>
+    void KMeansRex<T>::SampleRowsPlusPlus(T *X_IN, int N, int D,
+                                          int K, int seed, T *Mu_OUT) {
+        set_seed(seed);
+
+        ExtMat X(X_IN, N, D);
+        ExtMat Mu(Mu_OUT, K, D);
+
+        sampleRowsPlusPlus(X, Mu);
     }
-    return newk;
-}
 
-void select_without_replacement( int N, int K, Vec &chosenIDs) {
-    Vec p = Vec::Ones(N);
-    for (int kk =0; kk<K; kk++) {
-        int choice;
-        int doKeep = false;
-        while ( doKeep==false) {
-            doKeep=true;
-            choice = discrete_rand( p );
-      
-            for (int previd=0; previd<kk; previd++) {
-                if (chosenIDs[previd] == choice ) {
-                doKeep = false;
-                break;
-                }
-            }      
-        }      
-        chosenIDs[kk] = choice;     
+
+    // ====================================================== Utility Functions
+
+    template<typename T>
+    void KMeansRex<T>::set_seed(int seed) {
+        init_genrand(seed);
     }
-}
 
-// ======================================================= Init Cluster Locs Mu
+    template<typename T>
+    int KMeansRex<T>::discrete_rand(Vec &p) {
+        double total = p.sum();
+        int K = (int) p.size();
 
-void sampleRowsRandom( ExtMat &X, ExtMat &Mu ) {
-    int N = X.rows();
-    int K = Mu.rows();
-    Vec ChosenIDs = Vec::Zero(K);
-    select_without_replacement(N, K, ChosenIDs);
-    for (int kk=0; kk<K; kk++) {
-        Mu.row( kk ) = X.row( ChosenIDs[kk] );
-    }
-}
-
-void sampleRowsPlusPlus( ExtMat &X, ExtMat &Mu ) {
-    int N = X.rows();
-    int K = Mu.rows();
-    if (K > N) {
-        // User requested more clusters than we have available.
-        // So, we'll fill only first N rows of Mu
-        // and leave all remaining rows of Mu uninitialized.
-        K = N;
-    }
-    Vec ChosenIDs = Vec::Ones(K);
-    int choice = discrete_rand(ChosenIDs);
-    Mu.row(0) = X.row( choice );
-    ChosenIDs[0] = choice;
-    Vec minDist(N);
-    Vec curDist(N);
-    for (int kk=1; kk<K; kk++) {
-        curDist = (X.rowwise() - Mu.row(kk-1)).square().rowwise().sum().sqrt();
-        if (kk==1) {
-            minDist = curDist;
-        } else {
-            minDist = curDist.min( minDist );
-        }      
-        choice = discrete_rand( minDist );
-        ChosenIDs[kk] = choice;
-        Mu.row(kk) = X.row( choice );
-    }       
-}
-
-void init_Mu( ExtMat &X, ExtMat &Mu, char* initname ) {		  
-    if (string(initname) == "random") {
-        sampleRowsRandom( X, Mu );
-    } else if (string(initname) == "plusplus") {
-        sampleRowsPlusPlus( X, Mu );
-    }
-}
-
-// ======================================================= Update Assignments Z
-void pairwise_distance( ExtMat &X, ExtMat &Mu, Mat &Dist ) {
-    int N = X.rows();
-    int D = X.cols();
-    int K = Mu.rows();
-
-    // For small dims D, for loop is noticeably faster than fully vectorized.
-    // Odd but true.  So we do fastest thing 
-    if ( D <= 16 ) {
-        for (int kk=0; kk<K; kk++) {
-            Dist.col(kk) = (X.rowwise() - Mu.row(kk)).square().rowwise().sum();
-        }    
-    } else {
-        Dist = -2*(X.matrix() * Mu.transpose().matrix());
-        Dist.rowwise() += Mu.square().rowwise().sum().transpose().row(0);
-    }
-}
-
-double assignClosest( ExtMat &X, ExtMat &Mu, ExtMat &Z, Mat &Dist) {
-    double totalDist = 0;
-    int minRowID;
-
-    pairwise_distance( X, Mu, Dist );
-
-    for (int nn=0; nn<X.rows(); nn++) {
-        totalDist += Dist.row(nn).minCoeff( &minRowID );
-        Z(nn,0) = minRowID;
-    }
-    return totalDist;
-}
-
-// ======================================================= Update Locations Mu
-void calc_Mu( ExtMat &X, ExtMat &Mu, ExtMat &Z) {
-    //Mu = Mat::Zero(Mu.rows(), Mu.cols());
-    Mu.fill(0);
-    Vec NperCluster = Vec::Zero(Mu.rows());
-    for (int nn=0; nn<X.rows(); nn++) {
-        Mu.row((int) Z(nn,0)) += X.row(nn);
-        NperCluster[(int) Z(nn,0)] += 1;
-    }  
-    NperCluster += 1e-100; // avoid division-by-zero
-    for (int k=0; k < Mu.rows(); k++) {
-       Mu.row(k) /= NperCluster(k);
-    }
-}
-
-// ======================================================= Overall Lloyd Alg.
-void run_lloyd( ExtMat &X, ExtMat &Mu, ExtMat &Z, int Niter )  {
-    double prevDist,totalDist = 0;
-    Mat Dist = Mat::Zero( X.rows(), Mu.rows() );  
-
-    for (int iter=0; iter<Niter; iter++) {
-        totalDist = assignClosest( X, Mu, Z, Dist );
-        calc_Mu( X, Mu, Z );
-        if (prevDist == totalDist) {
-            break;
+        double r = total * genrand_double();
+        double cursum = p(0);
+        int newk = 0;
+        while (r >= cursum && newk < K - 1) {
+            newk++;
+            cursum += p[newk];
         }
-        prevDist = totalDist;
+        if (newk < 0 || newk >= K) {
+            cerr << "Badness. Chose illegal discrete value." << endl;
+            return -1;
+        }
+        return newk;
     }
+
+    template<typename T>
+    void KMeansRex<T>::select_without_replacement(int N, int K, Vec &chosenIDs) {
+        Vec p = Vec::Ones(N);
+        for (int kk = 0; kk < K; kk++) {
+            int choice;
+            int doKeep = false;
+            while (doKeep == false) {
+                doKeep = true;
+                choice = discrete_rand(p);
+
+                for (int previd = 0; previd < kk; previd++) {
+                    if (chosenIDs[previd] == choice) {
+                        doKeep = false;
+                        break;
+                    }
+                }
+            }
+            chosenIDs[kk] = choice;
+        }
+    }
+
+    // ======================================================= Init Cluster Locs Mu
+
+    template<typename T>
+    void KMeansRex<T>::sampleRowsRandom(ExtMat &X, ExtMat &Mu) {
+        int N = X.rows();
+        int K = Mu.rows();
+        Vec ChosenIDs = Vec::Zero(K);
+        select_without_replacement(N, K, ChosenIDs);
+        for (int kk = 0; kk < K; kk++) {
+            Mu.row(kk) = X.row(ChosenIDs[kk]);
+        }
+    }
+
+    template<typename T>
+    void KMeansRex<T>::sampleRowsPlusPlus(ExtMat &X, ExtMat &Mu) {
+        int N = X.rows();
+        int K = Mu.rows();
+        if (K > N) {
+            // User requested more clusters than we have available.
+            // So, we'll fill only first N rows of Mu
+            // and leave all remaining rows of Mu uninitialized.
+            K = N;
+        }
+        Vec ChosenIDs = Vec::Ones(K);
+        int choice = discrete_rand(ChosenIDs);
+        Mu.row(0) = X.row(choice);
+        ChosenIDs[0] = choice;
+        Vec minDist(N);
+        Vec curDist(N);
+        for (int kk = 1; kk < K; kk++) {
+            curDist = (X.rowwise() - Mu.row(kk - 1)).square().rowwise().sum().sqrt();
+            if (kk == 1) {
+                minDist = curDist;
+            } else {
+                minDist = curDist.min(minDist);
+            }
+            choice = discrete_rand(minDist);
+            ChosenIDs[kk] = choice;
+            Mu.row(kk) = X.row(choice);
+        }
+    }
+
+    template<typename T>
+    void KMeansRex<T>::init_Mu(ExtMat &X, ExtMat &Mu, char *initname) {
+        if (string(initname) == "random") {
+            sampleRowsRandom(X, Mu);
+        } else if (string(initname) == "plusplus") {
+            sampleRowsPlusPlus(X, Mu);
+        }
+    }
+
+    // ======================================================= Update Assignments Z
+    template<typename T>
+    void KMeansRex<T>::pairwise_distance(ExtMat &X, ExtMat &Mu, Mat &Dist) {
+        int N = X.rows();
+        int D = X.cols();
+        int K = Mu.rows();
+
+        // For small dims D, for loop is noticeably faster than fully vectorized.
+        // Odd but true.  So we do fastest thing
+        if (D <= 16) {
+            for (int kk = 0; kk < K; kk++) {
+                Dist.col(kk) = (X.rowwise() - Mu.row(kk)).square().rowwise().sum();
+            }
+        } else {
+            Dist = -2 * (X.matrix() * Mu.transpose().matrix());
+            Dist.rowwise() += Mu.square().rowwise().sum().transpose().row(0);
+        }
+    }
+
+    template<typename T>
+    double KMeansRex<T>::assignClosest(ExtMat &X, ExtMat &Mu, ExtMat &Z, Mat &Dist) {
+        double totalDist = 0;
+        int minRowID;
+
+        pairwise_distance(X, Mu, Dist);
+
+        for (int nn = 0; nn < X.rows(); nn++) {
+            totalDist += Dist.row(nn).minCoeff(&minRowID);
+            Z(nn, 0) = minRowID;
+        }
+        return totalDist;
+    }
+
+    // ======================================================= Update Locations Mu
+    template<typename T>
+    void KMeansRex<T>::calc_Mu(ExtMat &X, ExtMat &Mu, ExtMat &Z) {
+        //Mu = Mat::Zero(Mu.rows(), Mu.cols());
+        Mu.fill(0);
+        Vec NperCluster = Vec::Zero(Mu.rows());
+        for (int nn = 0; nn < X.rows(); nn++) {
+            Mu.row((int) Z(nn, 0)) += X.row(nn);
+            NperCluster[(int) Z(nn, 0)] += 1;
+        }
+        NperCluster += 1e-100; // avoid division-by-zero
+        for (int k = 0; k < Mu.rows(); k++) {
+            Mu.row(k) /= NperCluster(k);
+        }
+    }
+
+    // ======================================================= Overall Lloyd Alg.
+    template<typename T>
+    void KMeansRex<T>::run_lloyd(ExtMat &X, ExtMat &Mu, ExtMat &Z, int Niter) {
+        double prevDist, totalDist = 0;
+        Mat Dist = Mat::Zero(X.rows(), Mu.rows());
+
+        for (int iter = 0; iter < Niter; iter++) {
+            totalDist = assignClosest(X, Mu, Z, Dist);
+            calc_Mu(X, Mu, Z);
+            if (prevDist == totalDist) {
+                break;
+            }
+            prevDist = totalDist;
+        }
+    }
+
+    template class KMeansRex<float>;
+    template class KMeansRex<double>;
 }
 
 // ===========================================================================
@@ -207,23 +245,11 @@ void run_lloyd( ExtMat &X, ExtMat &Mu, ExtMat &Z, int Niter )  {
 
 void RunKMeans(double *X_IN,  int N,  int D, int K, int Niter, \
                int seed, char* initname, double *Mu_OUT, double *Z_OUT) {
-  set_seed(seed);
-
-  ExtMat X (X_IN, N, D);
-  ExtMat Mu (Mu_OUT, K, D);
-  ExtMat Z (Z_OUT, N, 1);
-
-  init_Mu(X, Mu, initname);
-  run_lloyd(X, Mu, Z, Niter );
+    KMeansRex::KMeansRex<double>(X_IN, N, D, K, Niter, seed, initname, Mu_OUT, Z_OUT);
 }
-
 
 void SampleRowsPlusPlus(double *X_IN,  int N,  int D, int K, \
                         int seed, double *Mu_OUT) {
-  set_seed(seed);
-
-  ExtMat X (X_IN, N, D);
-  ExtMat Mu (Mu_OUT, K, D);
-
-  sampleRowsPlusPlus(X, Mu);
+    KMeansRex::KMeansRex<double> kmeansrex;
+    kmeansrex.SampleRowsPlusPlus(X_IN, N, D, K, seed, Mu_OUT);
 }

--- a/src/KMeansRexCore.h
+++ b/src/KMeansRexCore.h
@@ -4,20 +4,55 @@
 
 #include "Eigen/Dense"
 #include <iostream>
-using namespace Eigen;
-using namespace std;
 
-/*  DEFINE Custom Type Names to make code more readable
-    ExtMat :  2-dim matrix/array externally defined (e.g. in Matlab or Python)
-*/
-typedef Map<ArrayXXd> ExtMat;
-typedef ArrayXXd Mat;
-typedef ArrayXd Vec;
 
-void set_seed( int seed );
-void select_without_replacement( int N, int K, Vec &chosenIDs);
-int discrete_rand( Vec &p );
+namespace KMeansRex {
 
-void init_Mu( ExtMat &X, ExtMat &Mu, char* initname );
-void run_lloyd( ExtMat &X, ExtMat &Mu, ExtMat &Z, int Niter);
+    using namespace Eigen;
+    using namespace std;
+
+/*
+ * DEFINE Custom Type Names to make code more readable
+ * ExtMat :  2-dim matrix/array externally defined (e.g. in Matlab or Python)
+ */
+
+    template<typename T>
+    class KMeansRex {
+
+        typedef Array<T, Dynamic, Dynamic> Mat;
+        typedef Array<T, Dynamic, 1> Vec;
+        typedef Map<Mat> ExtMat;
+
+    public:
+        KMeansRex();
+
+        KMeansRex(T *X_IN,  int N,  int D, int K, int Niter,
+                  int seed, char* initname, T *Mu_OUT, T *Z_OUT);
+
+        void SampleRowsPlusPlus(T *X_IN,  int N,  int D,
+                                int K, int seed, T *Mu_OUT);
+
+    private:
+        // ====================================================== Utility Functions
+        void set_seed( int seed );
+        int discrete_rand( Vec &p );
+        void select_without_replacement( int N, int K, Vec &chosenIDs);
+
+        // ======================================================= Init Cluster Locs Mu
+        void sampleRowsRandom( ExtMat &X, ExtMat &Mu );
+        void sampleRowsPlusPlus( ExtMat &X, ExtMat &Mu );
+        void init_Mu( ExtMat &X, ExtMat &Mu, char* initname );
+
+        // ======================================================= Update Assignments Z
+        void pairwise_distance( ExtMat &X, ExtMat &Mu, Mat &Dist );
+        double assignClosest( ExtMat &X, ExtMat &Mu, ExtMat &Z, Mat &Dist);
+
+        // ======================================================= Update Locations Mu
+        void calc_Mu( ExtMat &X, ExtMat &Mu, ExtMat &Z);
+
+        // ======================================================= Overall Lloyd Alg.
+        void run_lloyd( ExtMat &X, ExtMat &Mu, ExtMat &Z, int Niter );
+    };
+
+}
 


### PR DESCRIPTION
Here is a template class for KMeansRex to be able to change the used type / precision.

No functions were changed, only copied, except the externally callable ones, which use the new class now.
The class is wrapped in the namespace KMeansRex, so that a call looks like this 

``` c++
KMeansRex::KMeansRex<double>(X_IN, N, D, K, Niter, seed, initname, Mu_OUT, Z_OUT);
```

Matlab wrapper is changed as well, but not tested (I don't use matlab).
Python wrapper is not touched, but not tested either.
- One probably should implement the template class header only, but it makes no big difference, I guess.
- In addition one could replace the mersenne twister with the one from std lib?
